### PR TITLE
Fixed open file dialog when running in exwm

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,7 @@
 , makeWrapper
 , jdk
 , webkitgtk
+, gtk3
 , ... }:
 
 let
@@ -40,7 +41,8 @@ in stdenv.mkDerivation rec {
     cp -r $src/JDK\ Mission\ Control/* $out
     chmod +x $out/jmc
     wrapProgram "$out/jmc" \
-        --prefix LD_LIBRARY_PATH ':' "${libraryPath}"
+        --prefix LD_LIBRARY_PATH : "${libraryPath}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
     ln -s $out/jmc $out/bin/java-mission-control
     ln -s ${desktopItem}/share/applications $out/share/applications
   '';  


### PR DESCRIPTION
Should probably use https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-hooks, but I couldn't get that to work.

From what I understand from https://github.com/NixOS/nixpkgs/issues/149812, this can be a problem if you run Plasma and a lot of other window managers as well.